### PR TITLE
Tag links & namespace links

### DIFF
--- a/packages/loam-vscode/package.json
+++ b/packages/loam-vscode/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/CiceroIsBack/loam",
   "version": "0.25.4",
   "license": "MIT",
-  "publisher": "loam",
+  "publisher": "ciceroisback",
   "engines": {
     "vscode": "^1.70.0"
   },

--- a/packages/loam-vscode/src/core/model/note.ts
+++ b/packages/loam-vscode/src/core/model/note.ts
@@ -2,7 +2,7 @@ import { URI } from './uri';
 import { Range } from './range';
 
 export interface ResourceLink {
-  type: 'wikilink' | 'link';
+  type: 'wikilink' | 'link' | 'taglink';
   rawText: string;
   range: Range;
   isEmbed: boolean;

--- a/packages/loam-vscode/src/core/services/markdown-link.ts
+++ b/packages/loam-vscode/src/core/services/markdown-link.ts
@@ -7,6 +7,7 @@ export abstract class MarkdownLink {
   private static directLinkRegex = new RegExp(
     /\[(.*)\]\(<?([^#>]*)?#?([^\]>]+)?>?\)/
   );
+  private static tagLinkRegex = new RegExp(/#(\S+)/);
 
   public static analyzeLink(link: ResourceLink) {
     try {
@@ -30,6 +31,14 @@ export abstract class MarkdownLink {
           alias: alias ?? '',
         };
       }
+      if (link.type === 'taglink') {
+        const [, target] = this.tagLinkRegex.exec(link.rawText);
+        return {
+          target: target ?? '',
+          section: '',
+          alias: '',
+        };
+      }
       throw new Error(`Link of type ${link.type} is not supported`);
     } catch (e) {
       throw new Error(`Couldn't parse link ${link.rawText} - ${e}`);
@@ -50,6 +59,12 @@ export abstract class MarkdownLink {
     if (link.type === 'wikilink') {
       return {
         newText: `${embed}[[${newTarget}${sectionDivider}${newSection}${aliasDivider}${newAlias}]]`,
+        range: link.range,
+      };
+    }
+    if (link.type === 'taglink') {
+      return {
+        newText: `${embed}#${newTarget}`,
         range: link.range,
       };
     }

--- a/packages/loam-vscode/src/core/services/markdown-parser.ts
+++ b/packages/loam-vscode/src/core/services/markdown-parser.ts
@@ -166,7 +166,11 @@ export function createMarkdownParser(
 const getTextFromChildren = (root: Node): string => {
   let text = '';
   visit(root, node => {
-    if (node.type === 'text' || node.type === 'wikiLink') {
+    if (
+      node.type === 'text' ||
+      node.type === 'wikiLink' ||
+      node.type === 'taglink'
+    ) {
       text = text + ((node as any).value || '');
     }
   });
@@ -199,6 +203,13 @@ const tagsPlugin: ParserPlugin = {
         note.tags.push({
           label: tag.label,
           range: Range.createFromPosition(start, end),
+        });
+
+        note.links.push({
+          type: 'taglink',
+          rawText: `#${tag.label}`,
+          range: Range.createFromPosition(start, end),
+          isEmbed: false,
         });
       }
     }
@@ -323,6 +334,18 @@ const wikilinkPlugin: ParserPlugin = {
         rawText: literalContent,
         range,
         isEmbed,
+      });
+    }
+    if (note.type === 'taglink') {
+      const literalContent = noteSource.substring(
+        node.position!.start.offset!,
+        node.position!.end.offset!
+      );
+      note.links.push({
+        type: 'taglink',
+        rawText: literalContent,
+        range: astPositionToLoamRange(node.position!),
+        isEmbed: false,
       });
     }
     if (node.type === 'link' || node.type === 'image') {

--- a/packages/loam-vscode/src/core/services/markdown-provider.ts
+++ b/packages/loam-vscode/src/core/services/markdown-provider.ts
@@ -81,6 +81,28 @@ export class MarkdownResourceProvider implements ResourceProvider {
         }
         break;
       }
+      case 'taglink': {
+        let definitionUri = undefined;
+        for (const def of resource.definitions) {
+          if (def.label === target) {
+            definitionUri = def.url;
+            break;
+          }
+        }
+        if (isSome(definitionUri)) {
+          const definedUri = resource.uri.resolve(definitionUri);
+          targetUri =
+            workspace.find(definedUri, resource.uri)?.uri ??
+            URI.placeholder(definedUri.path);
+        } else {
+          targetUri =
+            target === ''
+              ? resource.uri
+              : workspace.find(target, resource.uri)?.uri ??
+                URI.placeholder(target);
+        }
+        break;
+      }
       case 'link': {
         // force ambiguous links to be treated as relative
         const path =

--- a/packages/loam-vscode/src/core/services/markdown-provider.ts
+++ b/packages/loam-vscode/src/core/services/markdown-provider.ts
@@ -53,7 +53,7 @@ export class MarkdownResourceProvider implements ResourceProvider {
     link: ResourceLink
   ) {
     let targetUri: URI | undefined;
-    const { target, section } = MarkdownLink.analyzeLink(link);
+    let { target, section } = MarkdownLink.analyzeLink(link);
     switch (link.type) {
       case 'wikilink': {
         let definitionUri = undefined;
@@ -62,6 +62,9 @@ export class MarkdownResourceProvider implements ResourceProvider {
             definitionUri = def.url;
             break;
           }
+        }
+        if (target.indexOf('/') !== -1) {
+          target = target.replace('/', '___');
         }
         if (isSome(definitionUri)) {
           const definedUri = resource.uri.resolve(definitionUri);

--- a/packages/loam-vscode/src/features/link-completion.ts
+++ b/packages/loam-vscode/src/features/link-completion.ts
@@ -212,6 +212,11 @@ export class WikilinkCompletionProvider
       item.insertText = useAlias
         ? `${identifier}|${resource.title}`
         : identifier;
+
+      if (item.insertText.indexOf('___') !== -1) {
+        item.insertText = item.insertText.replace('___', '/');
+      }
+
       item.commitCharacters = useAlias ? [] : linkCommitCharacters;
       item.range = replacementRange;
       item.command = COMPLETION_CURSOR_MOVE;
@@ -240,7 +245,7 @@ export class WikilinkCompletionProvider
           uri.path,
           vscode.CompletionItemKind.Interface
         );
-        item.insertText = uri.path;
+        item.insertText = uri.path.replace('___', '/');
         item.command = COMPLETION_CURSOR_MOVE;
         item.range = replacementRange;
         return item;

--- a/packages/loam-vscode/src/features/refactor.ts
+++ b/packages/loam-vscode/src/features/refactor.ts
@@ -47,6 +47,21 @@ export default async function activate(
               );
               break;
             }
+            case 'taglink': {
+              const identifier = loam.workspace.getIdentifier(
+                fromVsCodeUri(newUri),
+                [fromVsCodeUri(oldUri)]
+              );
+              const edit = MarkdownLink.createUpdateLinkEdit(connection.link, {
+                target: identifier,
+              });
+              renameEdits.replace(
+                toVsCodeUri(connection.source),
+                toVsCodeRange(edit.range),
+                edit.newText
+              );
+              break;
+            }
             case 'link': {
               const path = isAbsolute(target)
                 ? '/' + vscode.workspace.asRelativePath(newUri)

--- a/readme.md
+++ b/readme.md
@@ -14,8 +14,8 @@ Why "Loam"? Loam is a combination of "Logseq" + "Foam". Also, loam in the real w
 
 ### Features to Implement
 
-- [ ] support hierarchy in links (namespaces; has to change "/" to "\_\_")
-- [ ] support for tags as links (incl in backlinks section)
+- [x] support hierarchy in links (namespaces; has to change "/" to "\_\_")
+- [x] support for tags as links (incl in backlinks section)
 - [ ] support for block ids
 - [ ] support collapsed::true ?? (not important)
 - [ ] support TODO / DONE


### PR DESCRIPTION
Added support for switching '___" to '/' and vice-versa in pages that are part of a namespace. Closes #7 
Also added support for clicking tags like links (except in MD preview window). Closes #8 