### PR TITLE
Add Badge Linking to VS Code Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-# Loam
+<div align="center">
 
-_This is an early stage project under rapid development._
-
+# Loam  
+loam: Logseq + Foam (VS Code plugin)  
+_This is an early stage project under rapid development._  
+[![VSCode Marketplace](https://img.shields.io/vscode-marketplace/v/ciceroisback.loam.svg?style=flat-square&label=Install%20From%20VS%20Code%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=ciceroisback.loam)
+</div>
 Loam is a fork of the excellent [Foam](https://github.com/foambubble/foam) VS Code extension. The goal of Loam is to enable better compatibilty with Logseq. This way one can easily open their Logseq folder in VS Code and get a comparable note-taking experience.
 
 To see the features of Foam, check out [their README](https://github.com/foambubble/foam/blob/master/readme.md).
@@ -11,6 +14,7 @@ To see the features of Foam, check out [their README](https://github.com/foambub
 To enable automatic outlining and indenting, use the `Markdown All in One` extension.
 
 Why "Loam"? Loam is a combination of "Logseq" + "Foam". Also, loam in the real world is rich soul that is good for growing plants. My hope is that Loam will be a good foundation for your knowledge garden, and help you grow your thoughts.
+
 
 ### Features to Implement
 


### PR DESCRIPTION
- Added a badge linking to the VS Code Marketplace
- Centered part of the README
- Renamed `readme.md` to `README.md`

Unsure if I should add a more prominent "Installation" section in the README as the badge might not be too noticeable at a glance.

Also, @CiceroIsBack, perhaps you should change the default branch to `dev` in Github as that's where the major changes are happening and this project is not fully developed.